### PR TITLE
set px as default unit for props of type Number

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,8 +38,8 @@ const NightModeToggle = ({ size, checked, onChange, speed, ...extraProps }) => {
       style={{
         cursor: "pointer",
         overflow: "hidden",
-        width: `${sizeValue}${sizeUnit}`,
-        height: `${sizeValue * 0.47}${sizeUnit}`,
+        width: `${sizeValue}${sizeUnit || 'px'}`,
+        height: `${sizeValue * 0.47}${sizeUnit || 'px'}`,
         appearance: 'none',
         MozAppearance: 'none',
         WebkitAppearance: 'none',
@@ -54,10 +54,10 @@ const NightModeToggle = ({ size, checked, onChange, speed, ...extraProps }) => {
           display: "flex",
           alignItems: "center",
           justifyContent: "center",
-          marginTop: `${sizeValue * -0.595}${sizeUnit}`,
-          marginLeft: `${sizeValue * -0.32}${sizeUnit}`,
-          width: `${sizeValue * 1.65}${sizeUnit}`,
-          height: `${sizeValue * 1.65}${sizeUnit}`
+          marginTop: `${sizeValue * -0.595}${sizeUnit || 'px'}`,
+          marginLeft: `${sizeValue * -0.32}${sizeUnit || 'px'}`,
+          width: `${sizeValue * 1.65}${sizeUnit || 'px'}`,
+          height: `${sizeValue * 1.65}${sizeUnit || 'px'}`
         }}
       >
         <Lottie


### PR DESCRIPTION
#7 Looking at this issue I figured that the parse-unit library wasn't covering the default to px when a prop of type number was passed to the component, as my function was doing previously. Instead, when a number is passed, it returns an empty string as the sizeUnit, so adding a  `|| 'px'` next to the sizeUnit will do the trick👍.