### PR TITLE
Remove fade-in animation and fix first frame flashing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,6 @@ const NightModeToggle = ({ size, checked, onChange, speed, ...extraProps }) => {
   const ref = useRef();
   const [progress, setProgress] = useState(() => 0);
   const [sizeValue, sizeUnit] = parseUnit(size);
-  const [visible, setVisible] = useState(false);
   useEffect(() => {
     if (progress >= 0.5) {
       if (checked) {
@@ -28,8 +27,7 @@ const NightModeToggle = ({ size, checked, onChange, speed, ...extraProps }) => {
   useEffect(
     () => {
       /* force */
-      (!!checked) && ref.current.anim.advanceTime(1000);
-      setVisible(true);
+      (!!checked) && ref.current.anim.advanceTime(1300);
     },
     [],
   );
@@ -44,8 +42,6 @@ const NightModeToggle = ({ size, checked, onChange, speed, ...extraProps }) => {
     <button
       onClick={() => ref.current.anim.isPaused && onChange(!checked)}
       style={{
-        opacity: visible ? 1 : 0.25,
-        transition: "opacity 300ms",
         cursor: "pointer",
         overflow: "hidden",
         width: `${sizeValue}${sizeUnit || 'px'}`,

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ const NightModeToggle = ({ size, checked, onChange, speed, ...extraProps }) => {
   const ref = useRef();
   const [progress, setProgress] = useState(() => 0);
   const [sizeValue, sizeUnit] = parseUnit(size);
+  const segments = checked ? { segments: [2, 96] } : null;
   useEffect(() => {
     if (progress >= 0.5) {
       if (checked) {
@@ -74,6 +75,7 @@ const NightModeToggle = ({ size, checked, onChange, speed, ...extraProps }) => {
           eventListeners={eventListeners}
           forceSegments
           options={options}
+          {...segments}
         />
       </div>
     </button>


### PR DESCRIPTION
Solved the remaining problem in issue #8 about first frame flashing, for a better experience, fade-in animations have been removed.

At first, I wanted to use the segments attribute in Lottie to dynamically assign values ​​based on checked, so that the first frame can be skipped when checked is true, but the segments attribute in Lottie seems to have some problems.  and i decided to manually set the segments attribute in Lottie based on the checked attribute, also it can run perfectly.